### PR TITLE
Nmap scans, document title, charts cloning, minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Main application window contains four fields that act as an input
 - Scan - HP WebInspect / Burp Suite Pro scan
 - Knowledge base - knowledge base that could be used to reinforce
   final report customization
+- Nmap scan - parse XML output files from Nmap scans and include them
+  in the report
 
 Double click on given text area will popup the content on larger area.
 
@@ -55,14 +57,14 @@ Command-line support has been added in order to allow bulk generation
 of report-files. Application currently supports one set of switches:
 
 ```
--t template-file [-c content-file] [-k kb-file] [-s scan-file]
--r report-file
+-t template-file [-c content-file] [-k kb-file] [-s scan-file] [-n nmap-file]
+-r report-file [-o output-content-file]
 ```
 
 Example use:
 
 ```
-python report-ng.py -t examples/example-2-scan-report-template.xml -c examples/example-2-content.yaml -k examples/example-2-kb.yaml -s examples/example-2-scan-export-Burp.xml -r examples/\!.xml
+python report-ng.py -t examples/example-2-scan-report-template.xml -c examples/example-2-content.yaml -k examples/example-2-kb.yaml -s examples/example-2-scan-export-Burp.xml -r examples/\!.xml -o examples/\!.yaml
 ```
 
 ## Word Template Preparation

--- a/cxfreeze_setup.py
+++ b/cxfreeze_setup.py
@@ -2,7 +2,7 @@ from cx_Freeze import setup, Executable
 
 # Dependencies are automatically detected, but it might need
 # fine tuning.
-buildOptions = dict(packages=['lxml._elementpath', 'gzip'], excludes=[], compressed=True)
+buildOptions = dict(packages=['lxml._elementpath', 'gzip'], excludes=['collections.abc'], compressed=True)
 
 import sys
 base = 'Win32GUI' if sys.platform=='win32' else None

--- a/src/cli.py
+++ b/src/cli.py
@@ -39,7 +39,7 @@ class CLI(Version):
         def values (key):
             if key in sys.argv:
                 return map(lambda x: sys.argv[x + 1], filter(lambda x: x + 1 < len(sys.argv), filter(lambda x: sys.argv[x] == key, range(len(sys.argv)))))
-            return None
+            return [] #None caused error if empty.
         
         def is_csv (filename):
             ext = '.csv'
@@ -53,6 +53,7 @@ class CLI(Version):
         content_file = value('-c')
         kb_file = value('-k')
         scan_files = values('-s')
+        nmap_files = values('-n')
         report_file = value('-r')
         output_file = value('-o')
         summary_file = value('-u')
@@ -60,17 +61,23 @@ class CLI(Version):
         if template_file and report_file:
             report = Report()
             report.template_load_xml(template_file)
+
             if content_file:
                 if is_yaml(content_file):
                     report.content_load_yaml(content_file)
                 else:
                     report.content_load_json(content_file)
+
             for scan_file in scan_files:
                 #report.scan = Scan(scan_file)
                 scan = Scan(scan_file)
                 report.merge_scan(scan.modify())
                 report.content_refresh()
                 del scan
+
+            for nmap_file in nmap_files:
+                report.nmap_load_xml(nmap_file)
+
             if kb_file:
                 if is_csv(kb_file):
                     report.kb_load_csv(kb_file)
@@ -112,7 +119,7 @@ class CLI(Version):
         else:
             print 'Usage: '
             print
-            print '    ' + self.title + '.exe -t template-file [-c content-file] [-k kb-file] [[-s scan-file] ...] -r output-report-file [-o output-content-file]'
+            print '    ' + self.title + '.exe -t template-file [-c content-file] [-k kb-file] [[-s scan-file] ...] [[-n nmap-file] ...] -r output-report-file [-o output-content-file]'
             print '        generate report (and optionally - content as yaml / json)'
             print
             print '    ' + self.title + '.exe -s scan-file -o output-scan-file'

--- a/src/version.py
+++ b/src/version.py
@@ -31,9 +31,17 @@ class Version(object):
     Generate reports based on HP WebInspect, BurpSuite Pro scans,
     own custom data, knowledge base and Microsoft Office Word templates.
     '''
-    version = '1.0.2'
-    date = 'Tue Nov 14 12:12:45 2017'
+    version = '1.0.3'
+    date = 'Tuesday Jan 12 11:00:00 2021'
     changelog = '''
+    ''' + version + ''' - ''' + date + '''
+    - Nmap scan support for multiple XML files - gets enabled if 'OpenPorts' directive is found in the template
+    - FIX: Fixed deprecated functions e.g. icon/OnFileDrop handling
+    - Added support for multiple charts in the _xml_apply_chart functions via objects cloning
+    - Support for page titles in coreProperties - automatically generated if not set with Test.DocumentTitle
+    - FIX: Template filename is now resolved with abspath fixing the "empty directory" error
+    - FIX: Empty scan files directive in CLI would give a NoneType error, changed to an empty array
+
     1.0.2 - Tue Nov 14 12:12:45 2017
     - FIX: Handle null value in Burp custom finding description fields
 

--- a/src/yamled.py
+++ b/src/yamled.py
@@ -190,6 +190,7 @@ class YamledWindow(wx.Frame):
         self.icon = wx.EmptyIcon()
         self.icon.CopyFromBitmap(myBitmap)
         self.SetIcon(self.icon)
+
         # tree image list
         if self.T:
             self.tree_image_list = wx.ImageList(16, 16)
@@ -563,7 +564,8 @@ class YamledWindow(wx.Frame):
             self.DeleteNode(child)
         pos = self.n.index(item)
         self.stack_sizer.Hide(self.t[pos])
-        self.stack_sizer.Remove(self.t[pos])
+
+        self.stack_sizer.Remove(self.t[pos]) # todo: compare changelogs of WX library and find out why it's not passing
         self.t[pos].Destroy()
         self.tree.Delete(self.n[pos])
         del self.n[pos]
@@ -798,7 +800,7 @@ class YamledWindow(wx.Frame):
     def File_Save_As(self, e):
         openFileDialog = wx.FileDialog(self, 'Save Yaml As', '', '',
                                        'Yaml files (*.yaml)|*.yaml|All files (*.*)|*.*',
-                                       wx.FD_SAVE | wx.wx.FD_OVERWRITE_PROMPT)
+                                       wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
         if openFileDialog.ShowModal() == wx.ID_CANCEL:
                 return
         filename = openFileDialog.GetPath()


### PR DESCRIPTION
- Nmap scan support for multiple XML files - gets enabled if 'OpenPorts' directive is found in the template
- FIX: Fixed deprecated functions e.g. icon/OnFileDrop handling
- Added support for multiple charts in the _xml_apply_chart functions via objects cloning.
- Support for page titles in coreProperties - automatically generated if not set with Test.DocumentTitle
- FIX: Template filename is now resolved with abspath fixing the "empty directory" error
- FIX: Empty scan files directive in CLI would give a NoneType error, changed to an empty array
- Updated readme for the missing CLI options -o, -n.